### PR TITLE
Remove artefact type concept

### DIFF
--- a/app/controllers/artefacts_controller.rb
+++ b/app/controllers/artefacts_controller.rb
@@ -25,6 +25,6 @@ class ArtefactsController < ApplicationController
   end
 
   def artefact_params
-    params.require(:artefact).permit(:title, :artefact_type, :notes, :audio, :parent_id)
+    params.require(:artefact).permit(:title, :notes, :audio, :parent_id)
   end
 end

--- a/app/models/artefact.rb
+++ b/app/models/artefact.rb
@@ -7,10 +7,7 @@ class Artefact < ApplicationRecord
 
   has_one_attached :audio
 
-  enum :artefact_type, { mix: 0, contribution: 1, master: 2 }
-
   validates :title, presence: true
-  validates :artefact_type, presence: true
   validate :parent_belongs_to_same_song
 
   scope :top_level, -> { where(parent_id: nil) }

--- a/app/models/song.rb
+++ b/app/models/song.rb
@@ -7,7 +7,6 @@ class Song < ApplicationRecord
   validates :title, presence: true
   validates :tempo, numericality: { greater_than: 0 }, allow_nil: true
   validate :main_mix_belongs_to_song
-  validate :main_mix_is_a_mix
 
   default_scope { order(updated_at: :desc) }
 
@@ -17,13 +16,6 @@ class Song < ApplicationRecord
     return unless main_mix
     unless main_mix.song_id == id
       errors.add(:main_mix, "must belong to this song")
-    end
-  end
-
-  def main_mix_is_a_mix
-    return unless main_mix
-    unless main_mix.mix?
-      errors.add(:main_mix, "must be a mix")
     end
   end
 end

--- a/app/views/songs/show.html.slim
+++ b/app/views/songs/show.html.slim
@@ -48,70 +48,66 @@
 
 h2.text-xl.font-semibold.mb-4 Artefacts
 
-- %w[mix contribution master].each do |type|
-  - artefacts = @song.artefacts.top_level.where(artefact_type: Artefact.artefact_types[type])
-  - if artefacts.any?
-    .mb-6
-      h3.text-sm.font-semibold.uppercase.tracking-wide.opacity-70.mb-2 = type.pluralize.titleize
-      .space-y-3
-        - artefacts.each do |artefact|
-          .card.bg-base-200 class=("ring-1 ring-primary" if artefact == @song.main_mix)
-            .card-body.p-4
-              .flex.justify-between.items-start
-                div
-                  .flex.items-center.gap-2
-                    .font-medium = artefact.title
-                    - if artefact == @song.main_mix
-                      span.badge.badge-primary.badge-sm main mix
-                  - if artefact.notes.present?
-                    p.text-sm.opacity-70.mt-1 = artefact.notes
-                .flex.gap-1.flex-shrink-0
-                  - if artefact.mix? && artefact != @song.main_mix
-                    = button_to "Set as main mix", song_main_mix_path(@song), params: { artefact_id: artefact.id }, method: :patch, class: "btn btn-ghost btn-xs"
-                  = button_to "Delete", song_artefact_path(@song, artefact), method: :delete, class: "btn btn-ghost btn-xs text-error", data: { turbo_confirm: "Delete this artefact?" }
-              - if artefact.audio.attached?
-                .mt-3
-                  audio controls="" preload="metadata" class="w-full"
-                    source src=url_for(artefact.audio) type=artefact.audio.content_type
-              /! Child artefacts
-              - if artefact.children.any?
-                details.mt-3
-                  summary.cursor-pointer.text-sm.opacity-70.select-none
-                    | #{artefact.children.size} attached #{"artefact".pluralize(artefact.children.size)}
-                  .ml-4.mt-2.space-y-2
-                    - artefact.children.each do |child|
-                      .card.bg-base-300
-                        .card-body.p-3
-                          .flex.justify-between.items-start
-                            div
-                              .flex.items-center.gap-2
-                                .font-medium.text-sm = child.title
-                                span.badge.badge-ghost.badge-xs = child.artefact_type.titleize
-                              - if child.notes.present?
-                                p.text-xs.opacity-70.mt-1 = child.notes
-                            .flex.gap-1.flex-shrink-0
-                              = button_to "Delete", song_artefact_path(@song, child), method: :delete, class: "btn btn-ghost btn-xs text-error", data: { turbo_confirm: "Delete this artefact?" }
-                          - if child.audio.attached?
-                            .mt-2
-                              audio controls="" preload="metadata" class="w-full"
-                                source src=url_for(child.audio) type=child.audio.content_type
-              /! Artefact comments
-              - if artefact.comments.any? || true
-                details.mt-3
-                  summary.cursor-pointer.text-sm.opacity-70.select-none
-                    - count = artefact.comments.size
-                    - if count > 0
-                      | #{count} #{"comment".pluralize(count)}
-                    - else
-                      | Comments
-                  .mt-2
-                    div id=dom_id(artefact, :comments)
-                      - artefact.comments.each do |comment|
-                        div id=dom_id(comment)
-                          .chat class=("chat-end" if comment.user == current_user) class=("chat-start" unless comment.user == current_user)
-                            = render "comments/comment", comment: comment
-                    .mt-2 id=dom_id(artefact, :comment_form)
-                      = render "comments/form", url: song_artefact_comments_path(@song, artefact), placeholder: "Comment on this artefact..."
+- artefacts = @song.artefacts.top_level
+- if artefacts.any?
+  .space-y-3
+    - artefacts.each do |artefact|
+      .card.bg-base-200 class=("ring-1 ring-primary" if artefact == @song.main_mix)
+        .card-body.p-4
+          .flex.justify-between.items-start
+            div
+              .flex.items-center.gap-2
+                .font-medium = artefact.title
+                - if artefact == @song.main_mix
+                  span.badge.badge-primary.badge-sm main mix
+              - if artefact.notes.present?
+                p.text-sm.opacity-70.mt-1 = artefact.notes
+            .flex.gap-1.flex-shrink-0
+              - if artefact != @song.main_mix
+                = button_to "Set as main mix", song_main_mix_path(@song), params: { artefact_id: artefact.id }, method: :patch, class: "btn btn-ghost btn-xs"
+              = button_to "Delete", song_artefact_path(@song, artefact), method: :delete, class: "btn btn-ghost btn-xs text-error", data: { turbo_confirm: "Delete this artefact?" }
+          - if artefact.audio.attached?
+            .mt-3
+              audio controls="" preload="metadata" class="w-full"
+                source src=url_for(artefact.audio) type=artefact.audio.content_type
+          /! Child artefacts
+          - if artefact.children.any?
+            details.mt-3
+              summary.cursor-pointer.text-sm.opacity-70.select-none
+                | #{artefact.children.size} attached #{"artefact".pluralize(artefact.children.size)}
+              .ml-4.mt-2.space-y-2
+                - artefact.children.each do |child|
+                  .card.bg-base-300
+                    .card-body.p-3
+                      .flex.justify-between.items-start
+                        div
+                          .flex.items-center.gap-2
+                            .font-medium.text-sm = child.title
+                          - if child.notes.present?
+                            p.text-xs.opacity-70.mt-1 = child.notes
+                        .flex.gap-1.flex-shrink-0
+                          = button_to "Delete", song_artefact_path(@song, child), method: :delete, class: "btn btn-ghost btn-xs text-error", data: { turbo_confirm: "Delete this artefact?" }
+                      - if child.audio.attached?
+                        .mt-2
+                          audio controls="" preload="metadata" class="w-full"
+                            source src=url_for(child.audio) type=child.audio.content_type
+          /! Artefact comments
+          - if artefact.comments.any? || true
+            details.mt-3
+              summary.cursor-pointer.text-sm.opacity-70.select-none
+                - count = artefact.comments.size
+                - if count > 0
+                  | #{count} #{"comment".pluralize(count)}
+                - else
+                  | Comments
+              .mt-2
+                div id=dom_id(artefact, :comments)
+                  - artefact.comments.each do |comment|
+                    div id=dom_id(comment)
+                      .chat class=("chat-end" if comment.user == current_user) class=("chat-start" unless comment.user == current_user)
+                        = render "comments/comment", comment: comment
+                .mt-2 id=dom_id(artefact, :comment_form)
+                  = render "comments/form", url: song_artefact_comments_path(@song, artefact), placeholder: "Comment on this artefact..."
 
 /! Song comments
 .divider
@@ -145,13 +141,8 @@ h3.text-lg.font-semibold.mb-4 Upload Artefact
 
   .form-control
     label.label
-      span.label-text Type
-    = f.select :artefact_type, Artefact.artefact_types.keys.map { |t| [t.titleize, t] }, {}, class: "select select-bordered w-full"
-
-  .form-control
-    label.label
       span.label-text Attach to (optional)
-    = f.select :parent_id, @parent_artefacts.map { |a| ["#{a.title} (#{a.artefact_type.titleize})", a.id] }, { include_blank: "None (top-level)" }, class: "select select-bordered w-full"
+    = f.select :parent_id, @parent_artefacts.map { |a| [a.title, a.id] }, { include_blank: "None (top-level)" }, class: "select select-bordered w-full"
 
   .form-control
     label.label

--- a/db/migrate/20260210023039_remove_artefact_type_from_artefacts.rb
+++ b/db/migrate/20260210023039_remove_artefact_type_from_artefacts.rb
@@ -1,0 +1,5 @@
+class RemoveArtefactTypeFromArtefacts < ActiveRecord::Migration[8.1]
+  def change
+    remove_column :artefacts, :artefact_type, :integer, null: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_02_10_015059) do
+ActiveRecord::Schema[8.1].define(version: 2026_02_10_023039) do
   create_table "active_storage_attachments", force: :cascade do |t|
     t.bigint "blob_id", null: false
     t.datetime "created_at", null: false
@@ -40,7 +40,6 @@ ActiveRecord::Schema[8.1].define(version: 2026_02_10_015059) do
   end
 
   create_table "artefacts", force: :cascade do |t|
-    t.integer "artefact_type", null: false
     t.datetime "created_at", null: false
     t.text "notes"
     t.integer "parent_id"

--- a/spec/factories/artefacts.rb
+++ b/spec/factories/artefacts.rb
@@ -1,7 +1,6 @@
 FactoryBot.define do
   factory :artefact do
     sequence(:title) { |n| "Artefact #{n}" }
-    artefact_type { :mix }
     notes { nil }
     association :song
   end

--- a/spec/models/artefact_spec.rb
+++ b/spec/models/artefact_spec.rb
@@ -14,23 +14,23 @@ RSpec.describe Artefact, type: :model do
 
     it "optionally belongs to a parent artefact" do
       song = create(:song)
-      parent = create(:artefact, song: song, artefact_type: :mix)
-      child = create(:artefact, song: song, artefact_type: :contribution, parent: parent)
+      parent = create(:artefact, song: song)
+      child = create(:artefact, song: song, parent: parent)
       expect(child.parent).to eq(parent)
     end
 
     it "has many children artefacts" do
       song = create(:song)
-      parent = create(:artefact, song: song, artefact_type: :mix)
-      child1 = create(:artefact, song: song, artefact_type: :contribution, parent: parent)
-      child2 = create(:artefact, song: song, artefact_type: :contribution, parent: parent)
+      parent = create(:artefact, song: song)
+      child1 = create(:artefact, song: song, parent: parent)
+      child2 = create(:artefact, song: song, parent: parent)
       expect(parent.children).to contain_exactly(child1, child2)
     end
 
     it "nullifies children when parent is destroyed" do
       song = create(:song)
-      parent = create(:artefact, song: song, artefact_type: :mix)
-      child = create(:artefact, song: song, artefact_type: :contribution, parent: parent)
+      parent = create(:artefact, song: song)
+      child = create(:artefact, song: song, parent: parent)
       parent.destroy
       expect(child.reload.parent_id).to be_nil
     end
@@ -53,12 +53,6 @@ RSpec.describe Artefact, type: :model do
       expect(artefact.errors[:title]).to include("can't be blank")
     end
 
-    it "requires an artefact_type" do
-      artefact = build(:artefact, artefact_type: nil)
-      expect(artefact).not_to be_valid
-      expect(artefact.errors[:artefact_type]).to include("can't be blank")
-    end
-
     it "requires a song" do
       artefact = build(:artefact, song: nil)
       expect(artefact).not_to be_valid
@@ -67,7 +61,7 @@ RSpec.describe Artefact, type: :model do
     it "is invalid if parent belongs to a different song" do
       song1 = create(:song)
       song2 = create(:song)
-      parent = create(:artefact, song: song1, artefact_type: :mix)
+      parent = create(:artefact, song: song1)
       child = build(:artefact, song: song2, parent: parent)
       expect(child).not_to be_valid
       expect(child.errors[:parent]).to include("must belong to the same song")
@@ -75,30 +69,9 @@ RSpec.describe Artefact, type: :model do
 
     it "is valid if parent belongs to the same song" do
       song = create(:song)
-      parent = create(:artefact, song: song, artefact_type: :mix)
+      parent = create(:artefact, song: song)
       child = build(:artefact, song: song, parent: parent)
       expect(child).to be_valid
-    end
-  end
-
-  describe "enum" do
-    it "defines artefact_type enum with mix, contribution, and master" do
-      expect(Artefact.artefact_types).to eq("mix" => 0, "contribution" => 1, "master" => 2)
-    end
-
-    it "can be a mix" do
-      artefact = build(:artefact, artefact_type: :mix)
-      expect(artefact).to be_mix
-    end
-
-    it "can be a contribution" do
-      artefact = build(:artefact, artefact_type: :contribution)
-      expect(artefact).to be_contribution
-    end
-
-    it "can be a master" do
-      artefact = build(:artefact, artefact_type: :master)
-      expect(artefact).to be_master
     end
   end
 
@@ -112,8 +85,8 @@ RSpec.describe Artefact, type: :model do
 
     it "scopes top_level to artefacts without a parent" do
       song = create(:song)
-      parent = create(:artefact, song: song, artefact_type: :mix)
-      child = create(:artefact, song: song, artefact_type: :contribution, parent: parent)
+      parent = create(:artefact, song: song)
+      child = create(:artefact, song: song, parent: parent)
       expect(song.artefacts.top_level).to include(parent)
       expect(song.artefacts.top_level).not_to include(child)
     end

--- a/spec/models/song_spec.rb
+++ b/spec/models/song_spec.rb
@@ -11,8 +11,8 @@ RSpec.describe Song, type: :model do
 
     it "has many artefacts" do
       song = create(:song)
-      create(:artefact, song: song, artefact_type: :mix)
-      create(:artefact, song: song, artefact_type: :contribution)
+      create(:artefact, song: song)
+      create(:artefact, song: song)
 
       expect(song.artefacts.count).to eq(2)
     end
@@ -31,14 +31,14 @@ RSpec.describe Song, type: :model do
 
     it "can have a main mix set" do
       song = create(:song)
-      mix = create(:artefact, song: song, artefact_type: :mix)
+      mix = create(:artefact, song: song)
       song.update!(main_mix: mix)
       expect(song.reload.main_mix).to eq(mix)
     end
 
     it "nullifies main_mix when the artefact is destroyed" do
       song = create(:song)
-      mix = create(:artefact, song: song, artefact_type: :mix)
+      mix = create(:artefact, song: song)
       song.update!(main_mix: mix)
       mix.destroy
       expect(song.reload.main_mix).to be_nil
@@ -65,18 +65,10 @@ RSpec.describe Song, type: :model do
     it "is invalid if main_mix does not belong to the song" do
       song = create(:song)
       other_song = create(:song, creator: create(:user))
-      mix = create(:artefact, song: other_song, artefact_type: :mix)
+      mix = create(:artefact, song: other_song)
       song.main_mix = mix
       expect(song).not_to be_valid
       expect(song.errors[:main_mix]).to include("must belong to this song")
-    end
-
-    it "is invalid if main_mix is not a mix type" do
-      song = create(:song)
-      contribution = create(:artefact, song: song, artefact_type: :contribution)
-      song.main_mix = contribution
-      expect(song).not_to be_valid
-      expect(song.errors[:main_mix]).to include("must be a mix")
     end
   end
 

--- a/spec/requests/artefacts_spec.rb
+++ b/spec/requests/artefacts_spec.rb
@@ -18,21 +18,21 @@ RSpec.describe "Artefacts", type: :request do
       it "creates a new artefact" do
         expect {
           post song_artefacts_path(song), params: {
-            artefact: { title: "First Mix", artefact_type: "mix", audio: audio_file }
+            artefact: { title: "First Mix", audio: audio_file }
           }
         }.to change(Artefact, :count).by(1)
       end
 
       it "attaches the audio file" do
         post song_artefacts_path(song), params: {
-          artefact: { title: "First Mix", artefact_type: "mix", audio: audio_file }
+          artefact: { title: "First Mix", audio: audio_file }
         }
         expect(Artefact.last.audio).to be_attached
       end
 
       it "redirects to the song page" do
         post song_artefacts_path(song), params: {
-          artefact: { title: "First Mix", artefact_type: "mix", audio: audio_file }
+          artefact: { title: "First Mix", audio: audio_file }
         }
         expect(response).to redirect_to(song_path(song))
       end
@@ -40,22 +40,15 @@ RSpec.describe "Artefacts", type: :request do
       it "creates artefact without audio file" do
         expect {
           post song_artefacts_path(song), params: {
-            artefact: { title: "Placeholder Mix", artefact_type: "mix" }
+            artefact: { title: "Placeholder Mix" }
           }
         }.to change(Artefact, :count).by(1)
       end
 
-      it "sets the correct artefact type" do
-        post song_artefacts_path(song), params: {
-          artefact: { title: "Guitar Track", artefact_type: "contribution", audio: audio_file }
-        }
-        expect(Artefact.last).to be_contribution
-      end
-
       it "creates an artefact with a parent" do
-        parent = create(:artefact, song: song, artefact_type: :mix)
+        parent = create(:artefact, song: song)
         post song_artefacts_path(song), params: {
-          artefact: { title: "Guitar Part", artefact_type: "contribution", parent_id: parent.id }
+          artefact: { title: "Guitar Part", parent_id: parent.id }
         }
         child = Artefact.find_by(title: "Guitar Part")
         expect(child.parent).to eq(parent)
@@ -63,7 +56,7 @@ RSpec.describe "Artefacts", type: :request do
 
       it "creates an artefact without a parent" do
         post song_artefacts_path(song), params: {
-          artefact: { title: "Standalone Mix", artefact_type: "mix" }
+          artefact: { title: "Standalone Mix" }
         }
         expect(Artefact.last.parent_id).to be_nil
       end
@@ -73,22 +66,14 @@ RSpec.describe "Artefacts", type: :request do
       it "does not create an artefact without a title" do
         expect {
           post song_artefacts_path(song), params: {
-            artefact: { title: "", artefact_type: "mix" }
-          }
-        }.not_to change(Artefact, :count)
-      end
-
-      it "does not create an artefact without a type" do
-        expect {
-          post song_artefacts_path(song), params: {
-            artefact: { title: "No Type" }
+            artefact: { title: "" }
           }
         }.not_to change(Artefact, :count)
       end
 
       it "re-renders the song page" do
         post song_artefacts_path(song), params: {
-          artefact: { title: "", artefact_type: "mix" }
+          artefact: { title: "" }
         }
         expect(response).to have_http_status(:unprocessable_entity)
       end
@@ -115,7 +100,7 @@ RSpec.describe "Artefacts", type: :request do
 
     it "redirects to login" do
       post song_artefacts_path(song), params: {
-        artefact: { title: "Test", artefact_type: "mix" }
+        artefact: { title: "Test" }
       }
       expect(response).to redirect_to(login_path)
     end

--- a/spec/requests/main_mix_spec.rb
+++ b/spec/requests/main_mix_spec.rb
@@ -7,21 +7,21 @@ RSpec.describe "Main Mix", type: :request do
   before { sign_in(user) }
 
   describe "PATCH /songs/:song_id/main_mix" do
-    context "with a valid mix artefact" do
+    context "with a valid artefact" do
       it "sets the main mix" do
-        mix = create(:artefact, song: song, artefact_type: :mix)
+        mix = create(:artefact, song: song)
         patch song_main_mix_path(song), params: { artefact_id: mix.id }
         expect(song.reload.main_mix).to eq(mix)
       end
 
       it "redirects to the song page" do
-        mix = create(:artefact, song: song, artefact_type: :mix)
+        mix = create(:artefact, song: song)
         patch song_main_mix_path(song), params: { artefact_id: mix.id }
         expect(response).to redirect_to(song_path(song))
       end
 
       it "shows a success notice" do
-        mix = create(:artefact, song: song, artefact_type: :mix)
+        mix = create(:artefact, song: song)
         patch song_main_mix_path(song), params: { artefact_id: mix.id }
         follow_redirect!
         expect(response.body).to include("Main mix updated")
@@ -30,35 +30,19 @@ RSpec.describe "Main Mix", type: :request do
 
     context "when changing the main mix" do
       it "replaces the previous main mix" do
-        old_mix = create(:artefact, song: song, artefact_type: :mix, title: "Old Mix")
-        new_mix = create(:artefact, song: song, artefact_type: :mix, title: "New Mix")
+        old_mix = create(:artefact, song: song, title: "Old Mix")
+        new_mix = create(:artefact, song: song, title: "New Mix")
         song.update!(main_mix: old_mix)
 
         patch song_main_mix_path(song), params: { artefact_id: new_mix.id }
         expect(song.reload.main_mix).to eq(new_mix)
       end
     end
-
-    context "with a non-mix artefact" do
-      it "does not set the main mix" do
-        contribution = create(:artefact, song: song, artefact_type: :contribution)
-        patch song_main_mix_path(song), params: { artefact_id: contribution.id }
-        expect(song.reload.main_mix).to be_nil
-      end
-
-      it "redirects with an error" do
-        contribution = create(:artefact, song: song, artefact_type: :contribution)
-        patch song_main_mix_path(song), params: { artefact_id: contribution.id }
-        expect(response).to redirect_to(song_path(song))
-        follow_redirect!
-        expect(response.body).to include("must be a mix")
-      end
-    end
   end
 
   describe "DELETE /songs/:song_id/main_mix" do
     it "clears the main mix" do
-      mix = create(:artefact, song: song, artefact_type: :mix)
+      mix = create(:artefact, song: song)
       song.update!(main_mix: mix)
 
       delete song_main_mix_path(song)
@@ -66,7 +50,7 @@ RSpec.describe "Main Mix", type: :request do
     end
 
     it "redirects to the song page" do
-      mix = create(:artefact, song: song, artefact_type: :mix)
+      mix = create(:artefact, song: song)
       song.update!(main_mix: mix)
 
       delete song_main_mix_path(song)


### PR DESCRIPTION
- Drop artefact_type column from artefacts table
- Remove enum, validation, and type-based logic from Artefact model
- Remove main_mix_is_a_mix validation from Song (any artefact can be main mix)
- Remove artefact_type from permitted params in ArtefactsController
- Simplify songs/show view: flat artefact list, no type grouping, no type select
- Update all specs to remove artefact_type references and type-specific tests